### PR TITLE
Update _quarto.yml to try to make it ITN style

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -59,8 +59,8 @@ format:
   html:
     grid:
        sidebar-width: 260px
-    css: style.css
-    linkcolor: "#00C1D5"
+    css: assets/style_ITN.css
+    linkcolor: "#e0471c"
     mainfont: "Karla"
 
     sidebar: true

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,7 +6,7 @@ book:
   title: Containers for Scientists
   author: Candace Savonen
   date: "10/11/2024"
-  favicon: assets/favicon.ico
+  favicon: assets/ITN_favicon.ico
   bread-crumbs: false
 
   page-navigation: true
@@ -33,8 +33,8 @@ book:
     - About.qmd
 
   sidebar:
-    logo: "img/logo.png"
-    logo-href: "https://hutchdatascience.org/"
+    logo: "assets/ITN_logo.png"
+    logo-href: "https://www.itcrtraining.org/"
     foreground: "#1B365D"
 
   page-footer:
@@ -73,7 +73,7 @@ format:
 
     link-external-newwindow: true
 
-    image: img/favicon.ico
+    image: assets/ITN_favicon.ico
     license: "CC BY"
 knitr:
   opts_chunk:


### PR DESCRIPTION
Couldn't find anything in the OTTR Quarto history for switching an OTTR Quarto book to ITN style.

The changes done here are ....

in `_quarto.yml` 
* switching the favicon to the ITN favicon (two locations)
* switching the logo to the ITN logo
* switching the href for the logo to the ITN website